### PR TITLE
Support object peerid format in difference util

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // Set utils
-const difference = (set1, set2) => new Set([...set1].filter(x => !set2.has(x)))
+const difference = (set1, set2) => new Set([...set1].map(x => String(x)).filter(x => ![...set2].map(x => String(x)).includes(x)))
 
 // Poll utils
 const sleep = (time) => new Promise(resolve => setTimeout(resolve, time))


### PR DESCRIPTION
Hi,

After upgrading to new libp2p (0.40) we noticed that we have serious performance problems (battery drain on mobile). We've found out that we're using new PeerId format in which we have objects instead of strings, I think it has occurred across multiple packages in orbitdb too, where conversion id to string was the solution, but this issue is not critical and I suppose others also experience this after migrating to new libp2p and ipfs but they are not aware, however it affects performance, because _onPeerConnected and exchangeHeads  is called on every emitJoinAndLeaves tick, so the app is getting really busy.

This is the behavior I see:

`
new values Set(1) { PeerId(Qmaec9tu8vWtY89W3PY4sh2wAoSV2b7jdmooVtSqaAb6PW) }
old values Set(1) { PeerId(Qmaec9tu8vWtY89W3PY4sh2wAoSV2b7jdmooVtSqaAb6PW) }
difference Set(1) { PeerId(Qmaec9tu8vWtY89W3PY4sh2wAoSV2b7jdmooVtSqaAb6PW) }
`

After few small changes I made: 

`
new values Set(1) { PeerId(Qmaec9tu8vWtY89W3PY4sh2wAoSV2b7jdmooVtSqaAb6PW) }
old values Set(1) { PeerId(Qmaec9tu8vWtY89W3PY4sh2wAoSV2b7jdmooVtSqaAb6PW) }
difference Set(0) {}
`
